### PR TITLE
Corriger barre bleue sur page d'accueil ordinateur

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,10 @@
             position: relative;
         }
 
+        .timeline:not(:empty)::before {
+            display: block; /* Afficher la barre seulement quand il y a du contenu */
+        }
+
         .timeline::before {
             content: '';
             position: absolute;
@@ -449,6 +453,7 @@
             background: linear-gradient(to bottom, var(--python-blue), var(--python-yellow));
             transform: translateX(-50%);
             border-radius: 2px;
+            display: none; /* Masquer la barre par défaut */
         }
 
         .period {


### PR DESCRIPTION
Hide the timeline's vertical blue bar by default to prevent it from appearing on an empty homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-4517f81f-51dd-4f95-8817-755aca7f1d76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4517f81f-51dd-4f95-8817-755aca7f1d76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

